### PR TITLE
Added support for OAuth 2 tokens obtained from developer.wink.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Yet another Wink plugin for [homebridge](https://github.com/nfarina/homebridge).
 * Subscribes to Wink push notifications, instead of polling for device updates.
 * Written in ES7 (arrow functions, async/await, classes).
 * Accessory services and characteristics are defined declaratively.
+* Supports 3 methods of [authentication](#authentication) including API tokens obtained from [developer.wink.com](https://developer.wink.com)
 
 ## Installation
 
@@ -34,15 +35,52 @@ Yet another Wink plugin for [homebridge](https://github.com/nfarina/homebridge).
 | --------------- | -------- | ---------------------------------------------- |
 | `platform`      | X        | Must always be "Wink".                         |
 | `name`          | X        | Can be anything.                               |
-| `username`      | X        |                                                |
-| `password`      | X        |                                                |
-| `client_id`     |          | Client ID permitted to use password grant.     |
-| `client_secret` |          | Only required if you're providing a Client ID. |
+| `client_id`     | *        | See [Authentication](#authentication) |
+| `client_secret` | *        | See [Authentication](#authentication) |
+| `username`     | *        | See [Authentication](#authentication) |
+| `password` | *        | See [Authentication](#authentication) |
 | `hide_groups`   |          | List of Wink Device Groups/Types that will be hidden from Homebridge. (see Device Support table below) |
 | `hide_ids`      |          | List of Wink IDs that will be hidden from Homebridge. |
 | `fan_ids`       |          | List of Wink IDs (for binary switches or light switches/dimmers) that will be added as fans to Homebridge. |
 | `window_ids`    |          | List of Wink IDs that will be added as windows (instead of doors) to Homebridge. |
 | `direct_access` |          | Attempt to establish direct communication with the Wink hub. Defaults to `true`. |
+
+## Authentication
+
+homebridge-wink3 supports 3 methods of authentication.
+
+* [OAuth Authorization Code](#oauth-authorization-code)
+* [OAuth Password Grant](#oauth-password-grant)
+* [Android client ID](#android-client-id)
+
+#### OAuth Authorization Code
+
+This is the method of authentication preferred by Wink. Using API credentials obtained from [developer.wink.com](https://developer.wink.com), the plugin will direct the user to authenticate via the wink.com at startup.
+
+You need to provide the following configuration options: `client_id` and `client_secret`
+
+##### Obtaining a Client ID and secret
+
+1. Create an account at [developer.wink.com](https://developer.wink.com)
+2. [Create an application](https://developer.wink.com/clients/new), with the following information:
+  * Name: Homebridge
+  * Website: https://github.com/sibartlett/homebridge-wink3
+  * Redirect URI: http://<HOMEBRIDGE_IP>:8888
+  * Check "I agree to the terms and conditions"
+3. Wait for the application to be approved (may take hours)
+4. Once approved, the Client ID and Secret can be seen [here](https://developer.wink.com/clients).
+
+#### OAuth Password Grant
+
+If you have old Wink API credentials that support OAuth password grant.
+
+You need to provide the following configuration options: `client_id`, `client_secret`, `username` and `password`
+
+#### Android client ID
+
+If you'd prefer to use the client ID and secret associated with Wink's Android app.
+
+You need to provide the following configuration options: `username` and `password`
 
 ## Device support
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "compare-versions": "^3.0.1",
+    "ip": "^1.1.5",
     "lodash": "^4.17.4",
     "pubnub": "^4.8.0",
     "request": "^2.81.0",

--- a/src/authenticated.html
+++ b/src/authenticated.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Authenticated</title>
+    <link rel="stylesheet" href="https://wink-api-production.s3.amazonaws.com/oauth2_authorize/css/bootstrap.min.css">
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+    <link href="https://wink-api-production.s3.amazonaws.com/oauth2_authorize/css/style.css" rel="stylesheet">
+  </head>
+
+  <body style="">
+    <div class="container">
+      <div class="oauth2-wrapper">
+
+        <div class="signin-header">
+          <img class="signin-logo" src="https://wink-api-production.s3.amazonaws.com/oauth2_authorize/img/wink-logo.png">
+        </div>
+
+
+        <div class="client-description">
+          <p style="text-align: center">Homebridge successfully authenticated with Wink.</p>
+        </div>
+
+      </div>
+    </div>
+  </body>
+</html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,7 +1773,7 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-ip@^1.1.4:
+ip@^1.1.4, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
 


### PR DESCRIPTION
Wink have removed all references to password grant authentication in their [API documentation](http://docs.winkapiv2.apiary.io), and have also stopped issuing new API clients with permission to use password grant. This would indicate that password grants are being deprecated.

This pull request adds support to homebridge-wink3 for OAuth2 authorization code grant. When the plugin startups for the first time, the user will be directed to navigate to a login form hosted by Wink, and once they authenticate there they will be redirected back to the homebridge plugin.

* [x] Add support for oauth code authentication (web login workflow)
* [x] Handle expired access tokens
* [x] Handle expired refresh tokens
* [ ] Handle expired hub tokens
* [x] Update README