### PR TITLE
Fix service for door and window sensors

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -81,20 +81,17 @@ Limitations:
 _Spotter, Tripper and other PIR and Door/Window Sensors_
 
 * The following sensors are supported:
+  * Door and Window sensors
   * Humidity sensor
   * Motion sensor (PIR reports as Motion Detector)
   * Occupancy sensor
   * Temperature sensor
   * Water sensor (leak detector)
-* Door Sensors report as Doors by default. However, can be added to HomeKit as a window:
-  * using `window_ids` optional configuration field, or
-  * automatically if device's name contains the word "window" (such as "Living Room Window")
 * Reports Battery Level (where available).
 
 Limitations:
 
 * Spotter does not report brightness, vibration or loudness to HomeKit. Apple expects values and these are simply reported as yes/no concerning if it changed.
-* Door/Window Tamper Detection is not available in HomeKit.
 
 ## Shades
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Requires Node.js 6 or later.
 | `hide_groups`   |          | List of Wink Device Groups/Types that will be hidden from Homebridge. (see Device Support table below) |
 | `hide_ids`      |          | List of Wink IDs that will be hidden from Homebridge. |
 | `fan_ids`       |          | List of Wink IDs (for binary switches or light switches/dimmers) that will be added as fans to Homebridge. |
-| `window_ids`    |          | List of Wink IDs that will be added as windows (instead of doors) to Homebridge. |
 | `direct_access` |          | Attempt to establish direct communication with the Wink hub. Defaults to `true`. |
 
 ## Authentication

--- a/src/devices/sensor_pod.js
+++ b/src/devices/sensor_pod.js
@@ -1,17 +1,5 @@
 import { batteryService } from "./_shared";
 
-const isWindow = (state, device, config) => {
-  if (config.window_ids.indexOf(device.object_id) !== -1) {
-    return true;
-  }
-
-  return state.opened !== undefined && /\bwindow\b/i.test(device.name);
-};
-
-const isDoor = (state, device, config) => {
-  return state.opened !== undefined && !isWindow(state, device, config);
-};
-
 export default ({ Characteristic, Service }) => {
   return {
     type: "sensor_pod",
@@ -78,30 +66,17 @@ export default ({ Characteristic, Service }) => {
         ]
       },
       {
-        service: Service.Door,
-        supported: isDoor,
+        service: Service.ContactSensor,
+        supported: state => state.opened !== undefined,
         characteristics: [
           {
-            characteristic: Characteristic.CurrentPosition,
-            get: state => (state.opened ? 100 : 0)
+            characteristic: Characteristic.ContactSensorState,
+            get: state => (state.opened ? 1 : 0)
           },
           {
-            characteristic: Characteristic.PositionState,
-            value: Characteristic.PositionState.STOPPED
-          }
-        ]
-      },
-      {
-        service: Service.Window,
-        supported: isWindow,
-        characteristics: [
-          {
-            characteristic: Characteristic.CurrentPosition,
-            get: state => (state.opened ? 100 : 0)
-          },
-          {
-            characteristic: Characteristic.PositionState,
-            value: Characteristic.PositionState.STOPPED
+            characteristic: Characteristic.StatusTampered,
+            supported: state => state.tamper_detected !== undefined,
+            get: state => state.tamper_detected
           }
         ]
       },


### PR DESCRIPTION
- Door and window sensors are currently using incorrect services within HomeKit
- The correct service should be ContactSensor (not Door or Window)
- ContactSensor is read only, Door and Window are read/write
- This addresses issue #47 
- The icon shown in the Home app can be set manually within the app (door, window, etc.), but cannot be specified via Homebridge, so the `window_ids` support is removed