### PR TITLE
Remove the Android app's Client ID and secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Yet another Wink plugin for [homebridge](https://github.com/nfarina/homebridge).
 * Subscribes to Wink push notifications, instead of polling for device updates.
 * Written in ES7 (arrow functions, async/await, classes).
 * Accessory services and characteristics are defined declaratively.
-* Supports 3 methods of [authentication](#authentication) including API tokens obtained from [developer.wink.com](https://developer.wink.com)
+* Supports 2 methods of [authentication](#authentication) including API tokens obtained from [developer.wink.com](https://developer.wink.com)
 
 ## Contents
 
@@ -15,7 +15,6 @@ Yet another Wink plugin for [homebridge](https://github.com/nfarina/homebridge).
 3. [Authentication](#authentication)
     1. [OAuth Authorization Code](#oauth-authorization-code)
     2. [OAuth Password Grant](#oauth-password-grant)
-    3. [Android client ID](#android-client-id)
 4. [Device support](#device-support)
 4. [FAQ](#faq)
 5. [Acknowledgements](#acknowledgements)
@@ -49,10 +48,10 @@ Requires Node.js 6 or later.
 | --------------- | -------- | ---------------------------------------------- |
 | `platform`      | X        | Must always be "Wink".                         |
 | `name`          | X        | Can be anything.                               |
-| `client_id`     | *        | See [Authentication](#authentication) |
-| `client_secret` | *        | See [Authentication](#authentication) |
-| `username`     | *        | See [Authentication](#authentication) |
-| `password` | *        | See [Authentication](#authentication) |
+| `client_id`     | X        | See [Authentication](#authentication) |
+| `client_secret` | X        | See [Authentication](#authentication) |
+| `username`      | *        | See [Authentication](#authentication) |
+| `password`      | *        | See [Authentication](#authentication) |
 | `hide_groups`   |          | List of Wink Device Groups/Types that will be hidden from Homebridge. (see Device Support table below) |
 | `hide_ids`      |          | List of Wink IDs that will be hidden from Homebridge. |
 | `fan_ids`       |          | List of Wink IDs (for binary switches or light switches/dimmers) that will be added as fans to Homebridge. |
@@ -64,7 +63,6 @@ homebridge-wink3 supports 3 methods of authentication.
 
 * [OAuth Authorization Code](#oauth-authorization-code) (Preferred)
 * [OAuth Password Grant](#oauth-password-grant)
-* [Android client ID](#android-client-id)
 
 #### OAuth Authorization Code
 
@@ -91,12 +89,6 @@ If you have old Wink API credentials that support OAuth password grant.
 
 You need to provide the following configuration options: `client_id`, `client_secret`, `username` and `password`
 
-#### Android client ID
-
-If you'd prefer to use the client ID and secret associated with Wink's Android app.
-
-You need to provide the following configuration options: `username` and `password`
-
 ## Device support
 
 See [DEVICES.md](DEVICES.md) for more detailed information.
@@ -122,7 +114,7 @@ See [DEVICES.md](DEVICES.md) for more detailed information.
 
 #### Chamberlain garage opener does not seem to response to commands
 
-Unfortunately, Chamberlain garage openers are only controllable when using [Android client ID authentication](#android-client-id). ([Source](https://github.com/python-wink/python-wink/issues/23#issuecomment-197431701))
+Unfortunately, Chamberlain garage openers are only controllable when using a Client ID and Secret obtained from one of the official Wink apps. ([Source](https://github.com/python-wink/python-wink/issues/23#issuecomment-197431701))
 
 #### GoControl garage opener does not seem to response to commands
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "compare-versions": "^3.0.1",
     "ip": "^1.1.5",
+    "joi": "12.0.0",
     "lodash": "^4.17.4",
     "pubnub": "^4.12.0",
     "request": "^2.81.0",

--- a/src/WinkClient.js
+++ b/src/WinkClient.js
@@ -6,9 +6,6 @@ import ip from "ip";
 import request from "request-promise-native";
 import debounce from "./debounce";
 
-const android_client_id = "quirky_wink_android_app";
-const android_client_secret = "e749124ad386a5a35c0ab554a4f2c045";
-
 export default class WinkClient {
   constructor({ config, log, updateConfig }) {
     this.config = config;
@@ -32,7 +29,7 @@ export default class WinkClient {
     const accessToken = hub ? hub.access_token : this.config.access_token;
     const headers = {
       "User-Agent":
-        "Manufacturer/Apple-iPhone8_1 iOS/10.3.1 WinkiOS/5.8.0.27-production-release (Scale/2.00)"
+        "Manufacturer/Apple-iPhone8_1 iOS/11.1.1 WinkiOS/6.5.1.0-production-release (Scale/2.00)"
     };
 
     if (accessToken && options.uri !== "/oauth2/token") {
@@ -78,8 +75,8 @@ export default class WinkClient {
     this.log("Refreshing access token...");
     return this.getToken({
       grant_type: "refresh_token",
-      client_id: this.config.client_id || android_client_id,
-      client_secret: this.config.client_secret || android_client_secret,
+      client_id: this.config.client_id,
+      client_secret: this.config.client_secret,
       refresh_token: this.config.refresh_token
     })
       .then(response => {
@@ -107,8 +104,8 @@ export default class WinkClient {
       if (this.config.username && this.config.password) {
         return resolve({
           grant_type: "password",
-          client_id: this.config.client_id || android_client_id,
-          client_secret: this.config.client_secret || android_client_secret,
+          client_id: this.config.client_id,
+          client_secret: this.config.client_secret,
           username: this.config.username,
           password: this.config.password
         });
@@ -272,8 +269,8 @@ export default class WinkClient {
           scope: "local_control",
           grant_type: "refresh_token",
           refresh_token: this.config.refresh_token,
-          client_id: this.config.client_id || android_client_id,
-          client_secret: this.config.client_secret || android_client_secret
+          client_id: this.config.client_id,
+          client_secret: this.config.client_secret
         }
       });
 

--- a/src/WinkPlatform.js
+++ b/src/WinkPlatform.js
@@ -1,9 +1,13 @@
 import childProcess from "child_process";
 import fs from "fs";
+
 import _ from "lodash";
 import compareVersions from "compare-versions";
+import Joi from "joi";
+
 import Accessories from "./Accessories";
 import AccessoryHelper from "./AccessoryHelper";
+import configSchema from "./configSchema";
 import devices from "./devices";
 import Subscriptions from "./Subscriptions";
 import WinkClient from "./WinkClient";
@@ -16,6 +20,12 @@ export default class WinkPlatform {
   constructor(log, config, api) {
     if (!config) {
       log("Plugin not configured.");
+      return;
+    }
+
+    const result = Joi.validate(config, configSchema);
+    if (result.error) {
+      log.error("Invalid config.", result.error.message);
       return;
     }
 
@@ -101,6 +111,10 @@ export default class WinkPlatform {
   }
 
   configureAccessory(accessory) {
+    if (!this.accessories) {
+      return;
+    }
+
     this.patchAccessory(accessory);
     this.accessories.add(accessory);
     this.log(

--- a/src/configSchema.js
+++ b/src/configSchema.js
@@ -1,0 +1,18 @@
+import Joi from "joi";
+
+export default Joi.object()
+  .keys({
+    platform: Joi.string().required(),
+    name: Joi.string().required(),
+
+    client_id: Joi.string().required(),
+    client_secret: Joi.string().required(),
+
+    username: Joi.string(),
+    password: Joi.string(),
+
+    access_token: Joi.string(),
+    refresh_token: Joi.string()
+  })
+  .unknown()
+  .with("username", "password");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1528,6 +1528,10 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
+hoek@4.x.x:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -1765,6 +1769,12 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
+isemail@3.x.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.0.0.tgz#c89a46bb7a3361e1759f8028f9082488ecce3dff"
+  dependencies:
+    punycode "2.x.x"
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -1782,6 +1792,14 @@ isstream@~0.1.2:
 jest-docblock@^20.0.1:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
+
+joi@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-12.0.0.tgz#46f55e68f4d9628f01bbb695902c8b307ad8d33a"
+  dependencies:
+    hoek "4.x.x"
+    isemail "3.x.x"
+    topo "2.x.x"
 
 js-tokens@^3.0.0:
   version "3.0.2"
@@ -2311,6 +2329,10 @@ pubnub@^4.12.0:
     superagent-proxy "^1.0.2"
     uuid "^3.0.1"
 
+punycode@2.x.x:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -2800,6 +2822,12 @@ tmp@^0.0.31:
 to-fast-properties@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+topo@2.x.x:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/topo/-/topo-2.0.2.tgz#cd5615752539057c0dc0491a621c3bc6fbe1d182"
+  dependencies:
+    hoek "4.x.x"
 
 tough-cookie@>=2.3.0, tough-cookie@~2.3.0:
   version "2.3.2"


### PR DESCRIPTION
* All user's will be required to provide their own Client ID and secret.
* homebridge-wink3 will no longer fallback to the Client ID and secret from Wink's Android app