### PR TITLE
Enable SSL communication for PubNub

### DIFF
--- a/src/Subscriptions.js
+++ b/src/Subscriptions.js
@@ -10,6 +10,7 @@ export default class Subscriptions extends EventEmitter {
   getOrAddSubscriber(subscribeKey) {
     if (!this.subscribers[subscribeKey]) {
       this.subscribers[subscribeKey] = new PubNub({
+        ssl:true,
         subscribeKey
       });
 


### PR DESCRIPTION
This makes the communication with PubNub more secure.  this update sends device info, including lng/lat coordinates, so its best to use SSL.