### PR TITLE
Added null check to battery supported check.

### DIFF
--- a/src/devices/_shared.js
+++ b/src/devices/_shared.js
@@ -9,7 +9,7 @@ export const batteryService = options => {
 
   const service = {
     service: Service.BatteryService,
-    supported: state => state[field] !== undefined,
+    supported: state => state[field] !== undefined && state[field] !== null,
     characteristics: [
       {
         characteristic: Characteristic.BatteryLevel,


### PR DESCRIPTION
For certain garage door openers that do not have a battery, Wink will return a null value for the battery state. This results in a low-battery warning. This added null check will prevent the warning.